### PR TITLE
Use crypto/sha256 instead of crypto/md5 for FIPS compliance.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module resty.dev/v3
 
-go 1.21
+go 1.24.0
 
-require golang.org/x/net v0.33.0
+toolchain go1.24.6
+
+require golang.org/x/net v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
+golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=

--- a/util.go
+++ b/util.go
@@ -7,8 +7,8 @@ package resty
 
 import (
 	"bytes"
-	"crypto/md5"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -403,13 +403,12 @@ var osHostname = os.Hostname
 // readMachineID generates and returns a machine id.
 // If this function fails to get the hostname it will cause a runtime error.
 func readMachineID() []byte {
-	var sum [3]byte
-	id := sum[:]
+	const idSize = 3
+	id := make([]byte, idSize)
 
 	if hostname, err := osHostname(); err == nil {
-		hw := md5.New()
-		_, _ = hw.Write([]byte(hostname))
-		copy(id, hw.Sum(nil))
+		hash := sha256.Sum256([]byte(hostname))
+		copy(id, hash[:idSize])
 		return id
 	}
 


### PR DESCRIPTION
Use crypto/sha256 instead of crypto/md5 for FIPS compliance.

Update deps